### PR TITLE
Fully upgraded clone pods have a chance to give powers

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -309,6 +309,12 @@ mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutat
 	var/datum/mutation/human/HM = pick(good_mutations)
 	. = HM.force_give(M)
 
+/proc/randmutvg(mob/living/carbon/M)
+	if(!M.has_dna())
+		return
+	var/datum/mutation/human/HM = pick((good_mutations) - mutations_list[HULK])
+	. = HM.force_give(M)
+
 /proc/randmuti(mob/living/carbon/M)
 	if(!M.has_dna())
 		return

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -167,7 +167,7 @@
 		for(var/A in bad_se_blocks)
 			setblock(H.dna.struc_enzymes, A, construct_block(0,2))
 	if(efficiency > 3 && prob(20))
-		randmutg(H)
+		randmutvg(H)
 	if(efficiency < 3 && prob(50))
 		var/mob/M = randmutb(H)
 		if(ismob(M))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -166,7 +166,7 @@
 	if(efficiency > 2)
 		for(var/A in bad_se_blocks)
 			setblock(H.dna.struc_enzymes, A, construct_block(0,2))
-	if(efficiency > 5 && prob(20))
+	if(efficiency > 3 && prob(20))
 		randmutg(H)
 	if(efficiency < 3 && prob(50))
 		var/mob/M = randmutb(H)


### PR DESCRIPTION
:cl: XDTM
add: Fully upgraded cloning pods may give clones genetic powers.
/:cl:

The functionality was there, but it required a level 6 scanner for some reason.

On an unrelated note, it seems it should have a 50% chance of giving a disability if unupgraded, and it definitely does not do that at the moment.
